### PR TITLE
use normal netcat to fix transient liveness probe failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ZK_LOG_DIR=/var/log/zookeeper
 ARG ZK_DIST=zookeeper-3.4.14
 RUN set -x \
     && apt-get update \
-    && apt-get install -y wget netcat-openbsd \
+    && apt-get install -y wget netcat \
 	&& wget -q "http://www.apache.org/dist/zookeeper/$ZK_DIST/$ZK_DIST.tar.gz" \
     && tar -xzf "$ZK_DIST.tar.gz" -C /opt \
     && rm -r "$ZK_DIST.tar.gz" \


### PR DESCRIPTION
based on fix in https://github.com/kubernetes-retired/contrib/pull/2965/commits/8b110ebfd881f05cbfab6cb8167979ffad6b111a