### PR TITLE
Zookeeper 3.6.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-FROM openjdk:8u181-jdk
+FROM docker.io/openjdk:11
 
 ENV ZK_USER=zookeeper \
 ZK_DATA_DIR=/var/lib/zookeeper/data \
 ZK_DATA_LOG_DIR=/var/lib/zookeeper/log \
 ZK_LOG_DIR=/var/log/zookeeper
 
-ARG ZK_DIST=zookeeper-3.4.14
+ARG ZK_DIST=zookeeper-3.6.3
 RUN set -x \
     && apt-get update \
     && apt-get install -y wget netcat \
-	&& wget -q "http://www.apache.org/dist/zookeeper/$ZK_DIST/$ZK_DIST.tar.gz" \
-    && tar -xzf "$ZK_DIST.tar.gz" -C /opt \
-    && rm -r "$ZK_DIST.tar.gz" \
-    && ln -s /opt/$ZK_DIST /opt/zookeeper \
+    && wget -q "https://downloads.apache.org/zookeeper/$ZK_DIST/apache-$ZK_DIST-bin.tar.gz" \
+    && tar -xzf "apache-$ZK_DIST-bin.tar.gz" -C /opt \
+    && rm -r "apache-$ZK_DIST-bin.tar.gz" \
+    && ln -s /opt/apache-$ZK_DIST-bin /opt/zookeeper \
     && rm -rf /opt/zookeeper/CHANGES.txt \
     /opt/zookeeper/README.txt \
     /opt/zookeeper/NOTICE.txt \
@@ -39,12 +39,11 @@ COPY zkGenConfig.sh zkOk.sh zkMetrics.sh /opt/zookeeper/bin/
 # Create a user for the zookeeper process and configure file system ownership 
 # for nessecary directories and symlink the distribution as a user executable
 RUN set -x \
-	&& useradd $ZK_USER \
+    && useradd $ZK_USER \
     && [ `id -u $ZK_USER` -eq 1000 ] \
     && [ `id -g $ZK_USER` -eq 1000 ] \
     && mkdir -p $ZK_DATA_DIR $ZK_DATA_LOG_DIR $ZK_LOG_DIR /usr/share/zookeeper /tmp/zookeeper /usr/etc/ \
-	&& chown -R "$ZK_USER:$ZK_USER" /opt/$ZK_DIST $ZK_DATA_DIR $ZK_LOG_DIR $ZK_DATA_LOG_DIR /tmp/zookeeper \
-	&& ln -s /opt/zookeeper/conf/ /usr/etc/zookeeper \
-	&& ln -s /opt/zookeeper/bin/* /usr/bin \
-	&& ln -s /opt/zookeeper/$ZK_DIST.jar /usr/share/zookeeper/ \
-	&& ln -s /opt/zookeeper/lib/* /usr/share/zookeeper 
+    && chown -R "$ZK_USER:$ZK_USER" /opt/apache-$ZK_DIST-bin $ZK_DATA_DIR $ZK_LOG_DIR $ZK_DATA_LOG_DIR /tmp/zookeeper \
+    && ln -s /opt/zookeeper/conf/ /usr/etc/zookeeper \
+    && ln -s /opt/zookeeper/bin/* /usr/bin \
+    && ln -s /opt/zookeeper/lib/* /usr/share/zookeeper

--- a/zkGenConfig.sh
+++ b/zkGenConfig.sh
@@ -32,6 +32,8 @@ ZK_MAX_SESSION_TIMEOUT=${ZK_MAX_SESSION_TIMEOUT:- $((ZK_TICK_TIME*20))}
 ZK_SNAP_COUNT=${ZK_SNAP_COUNT:-100000}
 ZK_SNAP_RETAIN_COUNT=${ZK_SNAP_RETAIN_COUNT:-3}
 ZK_PURGE_INTERVAL=${ZK_PURGE_INTERVAL:-0}
+ZK_4LW_COMMANDS_WHITELIST=${ZK_4LW_COMMANDS_WHITELIST:-*}
+ZK_SNAPSHOT_TRUST_EMPTY=${ZK_SNAPSHOT_TRUST_EMPTY:-"false"}
 ID_FILE="$ZK_DATA_DIR/myid"
 ZK_CONFIG_FILE="$ZK_CONF_DIR/zoo.cfg"
 LOGGER_PROPS_FILE="$ZK_CONF_DIR/log4j.properties"
@@ -80,6 +82,9 @@ function validate_env() {
     echo "ZK_SNAP_COUNT=$ZK_SNAP_COUNT"
     echo "ZK_SNAP_RETAIN_COUNT=$ZK_SNAP_RETAIN_COUNT"
     echo "ZK_PURGE_INTERVAL=$ZK_PURGE_INTERVAL"
+    echo "ZK_4LW_COMMANDS_WHITELIST=$ZK_4LW_COMMANDS_WHITELIST"
+    echo "ZK_SNAPSHOT_TRUST_EMPTY=$ZK_SNAPSHOT_TRUST_EMPTY"
+
     echo "ENSEMBLE"
     print_servers
     echo "Environment validation successful"
@@ -101,6 +106,8 @@ function create_config() {
     echo "snapCount=$ZK_SNAP_COUNT" >> $ZK_CONFIG_FILE
     echo "autopurge.snapRetainCount=$ZK_SNAP_RETAIN_COUNT" >> $ZK_CONFIG_FILE
     echo "autopurge.purgeInterval=$ZK_PURGE_INTERVAL" >> $ZK_CONFIG_FILE
+    echo "4lw.commands.whitelist=$ZK_4LW_COMMANDS_WHITELIST" >>  $ZK_CONFIG_FILE
+    echo "snapshot.trust.empty=$ZK_SNAPSHOT_TRUST_EMPTY" >>  $ZK_CONFIG_FILE
 
     if [ $ZK_REPLICAS -gt 1 ]; then
     	print_servers >> $ZK_CONFIG_FILE


### PR DESCRIPTION
Shortcut: https://app.shortcut.com/mux/story/36392/upgrade-zookeeper
[sc-36392]

Upgrades Zookeeper to a stable supported version, 3.6.3. This upgrade has been tested and successfully rolled out in dos1 staging. This PR includes two more configuration flags:

`ZK_4LW_COMMANDS_WHITELIST`: Needed to enable the Zookeeper peers to issue commands to the Zookeeper node/pod, set to wildcard (`*`) by default with this change. Without this change, the Zookeeper pod was unable to form a cluster.

`ZK_SNAPSHOT_TRUST_EMPTY`: Sometimes needs to be set to `true` during the upgrade from Zookeeper 3.4. This has the Zookeeper node fall back to loading state from the transaction log if no snapshot is available, which is fine in that scenario. Set this to `false` under regular operation. See [Slack thread](https://mux.slack.com/archives/C010930929L/p1658534112974959?thread_ts=1658533543.635599&cid=C010930929L).